### PR TITLE
🐛fix: handle undefined value in TrendsChart formatter

### DIFF
--- a/src/components/activity/TrendsChart.tsx
+++ b/src/components/activity/TrendsChart.tsx
@@ -95,7 +95,7 @@ export default function TrendsChart({ steps, stepGoal }: TrendsChartProps) {
                 boxShadow: '0 8px 32px rgba(233, 30, 140, 0.2)',
               }}
               labelStyle={{ color: '#fff', fontWeight: 'bold' }}
-              formatter={(value) => [`${value.toLocaleString()} steps`, 'Steps']}
+              formatter={(value) => [value ? `${value.toLocaleString()} steps` : '0 steps', 'Steps']}
               cursor={{ fill: 'rgba(233, 30, 140, 0.1)' }}
             />
             <Bar dataKey="steps" fill="#E91E8C" radius={[8, 8, 0, 0]} />


### PR DESCRIPTION
## What changed?
Fixed TypeScript type error in TrendsChart tooltip formatter by checking if value is defined before calling toLocaleString().

## Why?
Vercel build was failing with "Type error: 'value' is possibly 'undefined'" in TrendsChart.tsx:98. Recharts Tooltip formatter can receive undefined values, so we need a null-safety check.

## Test status
- [x] TypeScript strict mode passes
- [x] Build succeeds
- [x] Manual testing in browser (N/A — no visual change, same behavior)