### PR TITLE
🐛fix: prevent 500s on tracking endpoint

### DIFF
--- a/src/app/actions/clientActions.ts
+++ b/src/app/actions/clientActions.ts
@@ -252,10 +252,10 @@ export async function addDailyWeight(
   );
 
   if (existingIndex >= 0) {
-    doc.dailyWeights[existingIndex] = { date: normalizedDate, weight, finalNotes };
+    doc.dailyWeights[existingIndex] = { date: normalizedDate, weight, notes: finalNotes };
   } else {
     if (!doc.dailyWeights) doc.dailyWeights = [];
-    doc.dailyWeights.push({ date: normalizedDate, weight, finalNotes });
+    doc.dailyWeights.push({ date: normalizedDate, weight, notes: finalNotes });
   }
 
   await doc.save();

--- a/src/app/api/clients/[clientId]/tracking/route.ts
+++ b/src/app/api/clients/[clientId]/tracking/route.ts
@@ -40,7 +40,22 @@ export async function POST(
     }
 
     // Parse and validate body
-    const body = await request.json();
+    const rawBody = await request.text();
+
+    let body: unknown;
+    try {
+      body = JSON.parse(rawBody);
+    } catch (err) {
+      console.error('[tracking] Invalid JSON body received', {
+        clientId,
+        contentType: request.headers.get('content-type'),
+        contentLength: request.headers.get('content-length'),
+        rawBody,
+        error: err instanceof Error ? err.message : String(err),
+      });
+      return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 });
+    }
+
     const parsed = TrackingEntrySchema.safeParse(body);
 
     if (!parsed.success) {

--- a/src/domain/types/DailySteps.ts
+++ b/src/domain/types/DailySteps.ts
@@ -1,9 +1,12 @@
 import { z } from "zod";
 
 export const DailyStepSchema = z.object({
-  date: z.date().max(new Date(), { message: "Date cannot be in the future" }),
+  date: z.date(),
   steps: z.number().int().min(0, { message: "Steps must be 0 or greater" }).max(100000, { message: "Steps cannot exceed 100,000" }),
   notes: z.string().optional(),
+}).refine((data) => data.date <= new Date(), {
+  message: "Date cannot be in the future",
+  path: ["date"]
 });
 
 export type DailyStep = z.infer<typeof DailyStepSchema>;

--- a/tests/unit/api/tracking.spec.ts
+++ b/tests/unit/api/tracking.spec.ts
@@ -36,6 +36,17 @@ function makeRequest(body: unknown, apiKey?: string): NextRequest {
   });
 }
 
+function makeRawRequest(rawBody: string, apiKey?: string): NextRequest {
+  const headers: Record<string, string> = { 'content-type': 'application/json' };
+  if (apiKey !== undefined) headers['x-api-key'] = apiKey;
+
+  return new NextRequest('http://localhost/api/clients/test-client/tracking', {
+    method: 'POST',
+    headers,
+    body: rawBody,
+  });
+}
+
 const VALID_CLIENT_ID = 'test-client';
 const VALID_API_KEY = 'valid-key-abc123';
 const VALID_PARAMS = Promise.resolve({ clientId: VALID_CLIENT_ID });
@@ -103,6 +114,53 @@ describe('POST /api/clients/[clientId]/tracking', () => {
     const res = await POST(req, { params: VALID_PARAMS });
 
     expect(res.status).toBe(400);
+  });
+
+  // ── Malformed body (Bug 1 regression) ─────────────────────────────────────
+
+  it('should return 400 (not 500) when the body is empty', async () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const req = makeRawRequest('', VALID_API_KEY);
+    const res = await POST(req, { params: VALID_PARAMS });
+
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe('Invalid JSON body');
+    expect(errorSpy).toHaveBeenCalled();
+
+    errorSpy.mockRestore();
+  });
+
+  it('should return 400 (not 500) when the body is malformed/truncated JSON', async () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const req = makeRawRequest('{"date": "2026-07-13", "steps":', VALID_API_KEY);
+    const res = await POST(req, { params: VALID_PARAMS });
+
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe('Invalid JSON body');
+    expect(errorSpy).toHaveBeenCalled();
+
+    errorSpy.mockRestore();
+  });
+
+  it('should log diagnostic details (raw body and content-type) when JSON parsing fails', async () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const req = makeRawRequest('not-json-at-all', VALID_API_KEY);
+    await POST(req, { params: VALID_PARAMS });
+
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining('tracking'),
+      expect.objectContaining({
+        rawBody: 'not-json-at-all',
+        contentType: 'application/json',
+      })
+    );
+
+    errorSpy.mockRestore();
   });
 
   // ── Dispatch ──────────────────────────────────────────────────────────────

--- a/tests/unit/app/actions/clientActions.spec.ts
+++ b/tests/unit/app/actions/clientActions.spec.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('@/lib/db/mongodb', () => ({
+  default: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('@/lib/models/Client', () => ({
+  ClientModel: { findById: vi.fn() },
+}));
+
+import { addDailyWeight } from '@/app/actions/clientActions';
+import { ClientModel } from '@/lib/models/Client';
+
+function makeFakeDoc(dailyWeights: any[] = []) {
+  const doc: any = {
+    dailyWeights,
+    save: vi.fn().mockResolvedValue(undefined),
+  };
+  doc.toObject = vi.fn().mockReturnValue({
+    _id: 'client-1',
+    name: 'Test',
+    coachId: 'coach-1',
+    plans: [],
+    dailySteps: [],
+    dailyWeights: doc.dailyWeights,
+    updatedAt: new Date('2026-07-13'),
+  });
+  return doc;
+}
+
+describe('addDailyWeight — notes persistence (Bug 3 regression)', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it('should include notes (not finalNotes) when pushing a new weight entry', async () => {
+    const doc = makeFakeDoc();
+    vi.mocked(ClientModel.findById).mockResolvedValue(doc);
+
+    await addDailyWeight('client-1', new Date('2026-07-10'), 80.5, 'After breakfast');
+
+    expect(doc.dailyWeights).toHaveLength(1);
+    expect(doc.dailyWeights[0]).toHaveProperty('notes', 'After breakfast');
+    expect(doc.dailyWeights[0]).not.toHaveProperty('finalNotes');
+    expect(doc.save).toHaveBeenCalledOnce();
+  });
+
+  it('should include notes (not finalNotes) when updating an existing weight entry for the same date', async () => {
+    const existingDate = new Date('2026-07-10');
+    existingDate.setHours(0, 0, 0, 0);
+    const doc = makeFakeDoc([{ date: existingDate, weight: 79.0, notes: 'old note' }]);
+    vi.mocked(ClientModel.findById).mockResolvedValue(doc);
+
+    await addDailyWeight('client-1', new Date('2026-07-10'), 81.0, 'Updated note');
+
+    expect(doc.dailyWeights[0]).toHaveProperty('notes', 'Updated note');
+    expect(doc.dailyWeights[0]).not.toHaveProperty('finalNotes');
+  });
+
+  it('should persist cleanly with no stray finalNotes key when no notes are provided', async () => {
+    const doc = makeFakeDoc();
+    vi.mocked(ClientModel.findById).mockResolvedValue(doc);
+
+    await addDailyWeight('client-1', new Date('2026-07-10'), 80.5);
+
+    expect(doc.dailyWeights[0]).not.toHaveProperty('finalNotes');
+    expect(doc.dailyWeights[0].notes).toBeUndefined();
+  });
+});

--- a/tests/unit/domain/types/DailySteps.spec.ts
+++ b/tests/unit/domain/types/DailySteps.spec.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { DailyStepSchema } from '@/domain/types/DailySteps';
+
+describe('DailyStepSchema', () => {
+  it('should accept a valid step entry with notes', () => {
+    const valid = {
+      date: new Date('2026-04-19'),
+      steps: 8000,
+      notes: 'Morning walk',
+    };
+    expect(() => DailyStepSchema.parse(valid)).not.toThrow();
+  });
+
+  it('should accept a valid step entry without notes', () => {
+    const noNotes = {
+      date: new Date('2026-04-19'),
+      steps: 8000,
+    };
+    expect(() => DailyStepSchema.parse(noNotes)).not.toThrow();
+  });
+
+  it('should accept today date', () => {
+    const today = new Date();
+    today.setHours(0, 0, 0, 0);
+    expect(() => DailyStepSchema.parse({ date: today, steps: 8000 })).not.toThrow();
+  });
+
+  it('should reject future dates', () => {
+    const future = {
+      date: new Date('2099-01-01'),
+      steps: 8000,
+    };
+    expect(() => DailyStepSchema.parse(future)).toThrow();
+  });
+
+  it('should reject negative steps', () => {
+    expect(() =>
+      DailyStepSchema.parse({ date: new Date('2026-04-19'), steps: -1 })
+    ).toThrow();
+  });
+
+  it('should accept 0 steps', () => {
+    expect(() =>
+      DailyStepSchema.parse({ date: new Date('2026-04-19'), steps: 0 })
+    ).not.toThrow();
+  });
+
+  it('should reject steps above 100000', () => {
+    expect(() =>
+      DailyStepSchema.parse({ date: new Date('2026-04-19'), steps: 100001 })
+    ).toThrow();
+  });
+
+  it('should accept exactly 100000 steps', () => {
+    expect(() =>
+      DailyStepSchema.parse({ date: new Date('2026-04-19'), steps: 100000 })
+    ).not.toThrow();
+  });
+
+  it('should make notes optional (undefined is fine)', () => {
+    const result = DailyStepSchema.parse({
+      date: new Date('2026-04-19'),
+      steps: 8000,
+    });
+    expect(result.notes).toBeUndefined();
+  });
+
+  describe('module-load-time freeze regression (Bug 2)', () => {
+    beforeEach(() => {
+      vi.useRealTimers();
+    });
+
+    it('should validate "today" correctly even when system clock has advanced significantly since module import', async () => {
+      // Simulate the schema module being loaded once at server boot.
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date('2026-01-01T00:00:00Z'));
+      vi.resetModules();
+      const { DailyStepSchema: FrozenAtBoot } = await import('@/domain/types/DailySteps');
+
+      // Simulate real wall-clock time passing in a long-running server
+      // process while the already-loaded module instance stays in memory.
+      vi.setSystemTime(new Date('2026-07-13T12:00:00Z'));
+
+      // Submit "today" (per the new current time) using the module
+      // instance that was loaded when "today" was still 2026-01-01.
+      const today = new Date('2026-07-13T12:00:00Z');
+      const result = FrozenAtBoot.safeParse({ date: today, steps: 5000 });
+
+      expect(result.success).toBe(true);
+
+      vi.useRealTimers();
+    });
+  });
+});


### PR DESCRIPTION
## What changed?
Guards against malformed/empty JSON bodies on the tracking endpoint, fixes a frozen-date bug in the DailySteps schema, and stops daily weight notes from being silently dropped — all covered with new unit tests (TDD).

## Why?
The endpoint was returning 500 in production (confirmed via Vercel logs) when it received an empty/malformed body. While investigating, two adjacent bugs were found and fixed in the same code path.

## Test status
- [x] Unit tests pass (47/47)
- [ ] E2E tests (not run locally — missing .env.local with real Mongo/Supabase credentials)
- [ ] Manual browser testing (N/A — external API endpoint, no UI)

## Notes
Added a console.error with diagnostic details (clientId, content-type, raw body) on JSON parse failures so future issues are visible in Vercel logs.